### PR TITLE
refs qorelanguage/qore#2345 fixed build errors with OSSP UUID (uuid_c…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,7 +462,7 @@ UUID uuid; UuidCreate(&uuid);
        LIBS="$LIBS $UUID_LIBS"
 
        # see if it's OSSP UUID
-       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <uuid.h>
    	   ]],[[
 uuid_t *up; uuid_create(&up);
@@ -473,7 +473,7 @@ uuid_t *up; uuid_create(&up);
        else
           # check for UNIX/Ted Ts'o's UUID library
           AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <uuid.h>
+#include <uuid/uuid.h>
 	  ]],[[
 #ifndef _UUID_STRING_t
 typedef char* uuid_string_t;

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -48,5 +48,5 @@ my string $uuid = UUID::get();
     - Initial release of the uuid module
     - Requires qore 0.8.0+ to build and run
 
-    
+
 */

--- a/src/uuid-module.h
+++ b/src/uuid-module.h
@@ -31,7 +31,11 @@
 #if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
 #define WIN_UUID 1
 #else
+#ifdef OSSP_UUID
 #include <uuid.h>
+#else
+#include <uuid/uuid.h>
+#endif
 #endif
 
 #ifndef _UUID_STRING_T


### PR DESCRIPTION
…reate() disappeared on Linux) and with libuuid (fixed includes)